### PR TITLE
streamlined make rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,73 @@
-stable-watermark:
-	docker run --privileged=true -v `pwd`:/paper -i -t docker-registry.usersys.redhat.com/asciidoctor:stable-alpha10-v1 asciidoctor-pdf -a pdf-style=asciidoctor-watermark -r asciidoctor-diagram $(doc)
-#NOTE: :/paper is the remote location within docker image, leave as is
+#
+# Build a PDF document from Asciidoc source using a Docker container
+#
+# The specified container includes the asciidoc software.  It runs the
+# document compiler on the source file (and any included files) and produces
+# a matching PDF file.
+#
 
-stable-no-watermark:
-	docker run --privileged=true -v `pwd`:/paper -i -t docker-registry.usersys.redhat.com/asciidoctor:stable-alpha10-v1 asciidoctor-pdf -a pdf-style=asciidoctor-no-watermark -r asciidoctor-diagram ose-dis-arch-Title.adoc
-#NOTE: :/paper is the remote location within docker image, leave as is
+all: draft
+
+# This is the default document source
+docroot=SETME_IN_MAKEFILE.adoc
+docpdf=$(basename $(docroot)).pdf
+
+# If the user has activated the docker group, no need to use sudo
+SUDO=$(shell id | grep -q '(docker)' || echo sudo)
+
+# Arguments for Docker to run with access to user file space
+DOCKER_SWITCHES=--interactive --tty --privileged
+
+# Mount the current working directory into the container to give access
+DOCUMENT_VOLUME=--volume `pwd`:/paper
+
+# Asciidoc compilation container image and release tags
+ASCIIDOC_IMAGE=docker-registry.usersys.redhat.com/asciidoctor
+ASCIIDOC_TAG_STABLE=stable-alpha10-v1
+ASCIIDOC_TAG_DEV=dev-2015-11-17
+
+#NOTE: :/paper is the internal location within docker image, leave as is
+# 
+
+#
+# Draft documents have a watermark to indicate that they are not ready for
+# release
+#
+draft:
+	$(SUDO) docker run $(DOCKER_SWITCHES) $(DOCUMENT_VOLUME) \
+	  $(ASCIIDOC_IMAGE):$(ASCIIDOC_TAG_STABLE) asciidoctor-pdf \
+	      -a pdf-style=asciidoctor-watermark -r asciidoctor-diagram $(docroot)
+
+#
+# Release documents do not have a DRAFT watermark
+#
+release:
+	$(SUDO) docker run $(DOCKER_SWITCHES) $(DOCUMENT_VOLUME) \
+	  $(ASCIIDOC_IMAGE):$(ASCIIDOC_TAG_STABLE) asciidoctor-pdf \
+	      -a pdf-style=asciidoctor-no-watermark -r asciidoctor-diagram $(docroot)
 
 clean:
-	find . -type f -name `basename "$(doc)" | cut -d. -f1`.pdf -exec rm -f {} \;
+	rm -f $(docpdf)
 	find . -type f -name \*.pdfmarks -exec rm -f {} \;
 
-
-
 # Below is used for development purposes. It can be used to check out the latest upstream asciidoctor-pdf features.
+#
+# Draft documents have a watermark to indicate that they are not ready for
+# release
+#
+draft-dev:
+	$(SUDO) docker run $(DOCKER_SWITCHES) $(DOCUMENT_VOLUME) \
+	  $(ASCIIDOC_IMAGE):$(ASCIIDOC_TAG_DEV) \
+	      ruby /asciidoctor-pdf/bin/asciidoctor-pdf \
+	        -a pdf-style=asciidoctor-watermark \
+	        -r asciidoctor-diagram $(docroot)
 
-dev-no-watermark:
-	docker run --privileged=true -v `pwd`:/paper -i -t docker-registry.usersys.redhat.com/asciidoctor:dev-2015-11-17 ruby /asciidoctor-pdf/bin/asciidoctor-pdf -a pdf-style=asciidoctor-no-watermark -r asciidoctor-diagram $(doc)
-#NOTE: :/paper is the remote location within docker image, leave as is
-
-dev-watermark:
-	docker run --privileged=true -v `pwd`:/paper -i -t docker-registry.usersys.redhat.com/asciidoctor:dev-2015-11-17 ruby /asciidoctor-pdf/bin/asciidoctor-pdf -a pdf-style=asciidoctor-watermark -r asciidoctor-diagram $(doc)
-#NOTE: :/paper is the remote location within docker image, leave as is
+#
+# Release documents do not have a DRAFT watermark
+#
+release-dev:
+	$(SUDO) docker run $(DOCKER_SWITCHES) $(DOCUMENT_VOLUME) \
+	  $(ASCIIDOC_IMAGE):$(ASCIIDOC_TAG_DEV) \
+	      ruby /asciidoctor-pdf/bin/asciidoctor-pdf \
+	        -a pdf-style=asciidoctor-no-watermark \
+	        -r asciidoctor-diagram $(docroot)

--- a/README.adoc
+++ b/README.adoc
@@ -1,0 +1,61 @@
+= PROJECT NAME
+Description
+Author <author email>
+
+== Editing
+
+The top level document is defined in the ``Makefile`` using the ``docroot``
+variable. This document includes the other components from the ``docs``,
+``images`` and ``code`` sub-directories when compiled.
+
+You must edit the ``Makefile`` and set the default document or provide the
+filename on the CLI as the ``docroot`` value
+
+== Compiling to PDF
+
+The ``Makefile`` provided uses a Docker image with the AsciiDoctor
+software embedded to compile the source to a PDF.
+
+    docker-registry.usersys.redhat.com/asciidoctor stable-alpha10-v1
+
+The default document root to compile is ``ose-dis-arch-Title.adoc``.
+
+By default the document is compiled with a _DRAFT_ watermark.  You can
+specify whether or not to include the watermark by providing a
+specific target for ``make``
+
+=== To create a draft document:
+
+A draft document will display a prominent pale red watermark with the
+word _DRAFT_ across the page.
+
+You can create a draft PDF from this source merely by calling _make_
+
+    make
+
+or
+
+    make draft
+
+To override the document root, add ``docroot=<filename>``
+
+   make draft docroot=ose-dis-arch-Title.adoc
+
+The other targets follow this pattern
+
+=== To create a release document:
+
+    make release
+
+=== To clean the directory:
+
+    make clean
+
+=== To create a draft doc with newer Asciidoc:
+
+    make draft-dev
+
+=== To create a release doc with newer Asciidoc:
+
+    make release-dev
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# refarch-asciidoc


### PR DESCRIPTION
This change sets defaults for document compilation and simplifies the ``make`` command needed to recompile drafts and release documents.

It also makes it easier to update the Docker build image and tags as needed.

It adds compilation instructions to the project README file.